### PR TITLE
mnt: set tz=UTC on request to ensure tz result

### DIFF
--- a/R/measures.R
+++ b/R/measures.R
@@ -70,7 +70,8 @@ riem_measures <- function(station = "VOHY",
       month2 = lubridate::month(date_end),
       day2 = lubridate::day(date_end),
       format = "tdf",
-      latlon = "yes"
+      latlon = "yes",
+      tz = "UTC"
     )
   )
 

--- a/tests/testthat/fixtures/measures/mesonet.agron.iastate.edu/cgi-bin/request/asos.py-f4a399.txt
+++ b/tests/testthat/fixtures/measures/mesonet.agron.iastate.edu/cgi-bin/request/asos.py-f4a399.txt
@@ -1,6 +1,6 @@
 #DEBUG: Format Typ    -> tdf
 #DEBUG: Time Period   -> 2014-03-01 00:00:00+00:00 2014-04-05 00:00:00+00:00
-#DEBUG: Time Zone     -> Etc/UTC
+#DEBUG: Time Zone     -> UTC
 #DEBUG: Data Contact   -> daryl herzmann akrherz@iastate.edu 515-294-5978
 #DEBUG: Entries Found -> -1
 station	valid	lon	lat	tmpf	dwpf	relh	drct	sknt	p01i	alti	mslp	vsby	gust	skyc1	skyc2	skyc3	skyc4	skyl1	skyl2	skyl3	skyl4	wxcodes	ice_accretion_1hr	ice_accretion_3hr	ice_accretion_6hr	peak_wind_gust	peak_wind_drct	peak_wind_time	feel	metar	snowdepth


### PR DESCRIPTION
My service you are requesting from had an intermediate bug whereby not providing a `tz=` value would result in timestamps in US Central Timezone.  This PR ensures  that `tz=UTC` is always set, which should future proof it.